### PR TITLE
Move all disassembler implementation details into disassemble.cpp

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -15,8 +15,6 @@
  * Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-#include <llvm-c/Disassembler.h>
-#include <llvm-c/Target.h>
 
 #include "app.hpp"
 #include "ArtProvider.hpp"
@@ -79,54 +77,6 @@ bool REHex::App::OnInit()
 	{
 		active_palette = Palette::create_system_palette();
 	}
-	
-	#ifdef LLVM_ENABLE_AARCH64
-	LLVMInitializeAArch64AsmPrinter();
-	LLVMInitializeAArch64Disassembler();
-	LLVMInitializeAArch64Target();
-	LLVMInitializeAArch64TargetInfo();
-	LLVMInitializeAArch64TargetMC();
-	#endif
-	
-	#ifdef LLVM_ENABLE_ARM
-	LLVMInitializeARMAsmPrinter();
-	LLVMInitializeARMDisassembler();
-	LLVMInitializeARMTarget();
-	LLVMInitializeARMTargetInfo();
-	LLVMInitializeARMTargetMC();
-	#endif
-	
-	#ifdef LLVM_ENABLE_MIPS
-	LLVMInitializeMipsAsmPrinter();
-	LLVMInitializeMipsDisassembler();
-	LLVMInitializeMipsTarget();
-	LLVMInitializeMipsTargetInfo();
-	LLVMInitializeMipsTargetMC();
-	#endif
-	
-	#ifdef LLVM_ENABLE_POWERPC
-	LLVMInitializePowerPCAsmPrinter();
-	LLVMInitializePowerPCDisassembler();
-	LLVMInitializePowerPCTarget();
-	LLVMInitializePowerPCTargetInfo();
-	LLVMInitializePowerPCTargetMC();
-	#endif
-	
-	#ifdef LLVM_ENABLE_SPARC
-	LLVMInitializeSparcAsmPrinter();
-	LLVMInitializeSparcDisassembler();
-	LLVMInitializeSparcTarget();
-	LLVMInitializeSparcTargetInfo();
-	LLVMInitializeSparcTargetMC();
-	#endif
-	
-	#ifdef LLVM_ENABLE_X86
-	LLVMInitializeX86AsmPrinter();
-	LLVMInitializeX86Disassembler();
-	LLVMInitializeX86Target();
-	LLVMInitializeX86TargetInfo();
-	LLVMInitializeX86TargetMC();
-	#endif
 	
 	REHex::MainWindow *window = new REHex::MainWindow();
 	window->Show(true);

--- a/src/disassemble.hpp
+++ b/src/disassemble.hpp
@@ -18,8 +18,6 @@
 #ifndef REHEX_DISASSEMBLE_HPP
 #define REHEX_DISASSEMBLE_HPP
 
-#include <llvm-c/Disassembler.h>
-#include <llvm-c/Target.h>
 #include <map>
 #include <string>
 #include <wx/choice.h>
@@ -58,7 +56,7 @@ namespace REHex {
 			SharedDocumentPointer document;
 			SafeWindowPointer<DocumentCtrl> document_ctrl;
 			
-			LLVMDisasmContextRef disassembler;
+			void* disassembler;
 			
 			wxChoice *arch;
 			CodeCtrl *assembly;


### PR DESCRIPTION
This hides all implementation details for the rest of the application,
making it easier to maintain / change the disassembler used.