### PR TITLE
Replace llvm disassembler with capstone

### DIFF
--- a/README.Windows.md
+++ b/README.Windows.md
@@ -14,26 +14,6 @@ Install path: C:\x86_64-w64-mingw32\
 
 You can use a different install path, but it will impact the following steps, and it MUST NOT contain any spaces.
 
-### CMake (required to build LLVM)
-
-Download and run the official CMake installer, enable the option to add it to your PATH.
-
-### Python (required to build LLVM)
-
-Download and run the official Python 3 installer, enable the option to add it to your PATH.
-
-### LLVM
-
-Unpack the LLVM source code and create a `build-release-static-x86_64` directory under it.
-
-Use the Start Menu shortcut created by the mingw-w64 installer to open a terminal and change to the `build-release-static-x86_64` directory.
-
-Run the following commands:
-
-    > cmake .. -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=C:\x86_64-w64-mingw32\llvm-7.0.0-release-static\ -DLLVM_BUILD_LLVM_DYLIB=OFF -G"MinGW Makefiles"
-    > cmake --build .
-    > cmake --build . --target install
-
 ### MSYS2
 
 Download and install MSYS2 from http://www.msys2.org/
@@ -85,6 +65,18 @@ Build and install Jansson.
     $ make
     $ make install
 
+### Capstone
+
+Open the MSYS2 command line.
+
+    $ cd capstone-4.0.2
+
+Edit the makefile, comment the next lines in the install step:
+    mkdir -p $(LIBDIR)
+    $(call install-library,$(LIBDIR))
+
+    $ PREFIX= DESTDIR=/mingw64 CAPSTONE_STATIC=yes CAPSTONE_BUILD_CORE_ONLY=yes CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ make install
+
 ## Build rehex
 
 Once the above steps are done, you should be able to build from the MSYS2 command line so long as you have the appropriate environment variables set.
@@ -93,7 +85,6 @@ Once the above steps are done, you should be able to build from the MSYS2 comman
     $ export CC=x86_64-w64-mingw32-gcc
     $ export CXX=x86_64-w64-mingw32-g++
     $ export WX_CONFIG=/c/x86_64-w64-mingw32/wxWidgets-3.0.4-release-static/bin/wx-config
-    $ export LLVM_CONFIG=/c/x86_64-w64-mingw32/llvm-7.0.0-release-static/bin/llvm-config
     
     $ make -f Makefile.win
     $ make -f Makefile.win check

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It is still in early development and should be considered in beta state at the m
 
 ## How can I run it?
 
-If you're running Linux, just checkout the source and run `make`. You will need Jansson, wxWidgets and LLVM installed, along with their development packages (Install `build-essential`, `git`, `libwxgtk3.0-dev`, `libjansson-dev` and `llvm-dev` on Ubuntu).
+If you're running Linux, just checkout the source and run `make`. You will need Jansson, wxWidgets and capstone installed, along with their development packages (Install `build-essential`, `git`, `libwxgtk3.0-dev`, `libjansson-dev` and `libcapstone-dev` on Ubuntu).
 
 If you're running Windows or OS X, the quickest way is to go to the commit history, follow a link to the relevant Buildkite job and download the binary from the artifacts tab.
 

--- a/src/disassemble.hpp
+++ b/src/disassemble.hpp
@@ -56,7 +56,7 @@ namespace REHex {
 			SharedDocumentPointer document;
 			SafeWindowPointer<DocumentCtrl> document_ctrl;
 			
-			void* disassembler;
+			size_t disassembler;
 			
 			wxChoice *arch;
 			CodeCtrl *assembly;


### PR DESCRIPTION
[capstone](https://www.capstone-engine.org/) is a library specifically built for this.

- Tested with WSL (linux build, instructions updated)
- Tested on msys2 (instructions updated)
- Tested on my MSVC port.

The disassembler uses intel syntax by default.
Unknown instructions are displayed as data (instead of halting the disassembly, called SKIPDATA mode)
I hope all disassembler architectures are configured correctly, I do not have samples available to confirm them all.
The code is formatted to look like the surrounding code. (Indented with tabs, empty lines also indented, no spaces around `(`, c-style comments, etc).