### PR TITLE
Fix font memory leaks

### DIFF
--- a/src/CodeCtrl.cpp
+++ b/src/CodeCtrl.cpp
@@ -42,6 +42,7 @@ END_EVENT_TABLE()
 
 REHex::CodeCtrl::CodeCtrl(wxWindow *parent, wxWindowID id):
 	wxControl(parent, id, wxDefaultPosition, wxDefaultSize, (wxVSCROLL | wxHSCROLL | wxWANTS_CHARS)),
+	font(wxFontInfo().Family(wxFONTFAMILY_MODERN)),
 	max_line_width(0),
 	offset_display_base(OFFSET_BASE_HEX),
 	offset_display_upper_bound(0xFFFFFFFF),
@@ -54,14 +55,10 @@ REHex::CodeCtrl::CodeCtrl(wxWindow *parent, wxWindowID id):
 	selection_begin(-1, -1),
 	selection_end(-1, -1)
 {
-	wxFontInfo finfo;
-	finfo.Family(wxFONTFAMILY_MODERN);
-	
-	font = new wxFont(finfo);
-	assert(font->IsFixedWidth());
+	assert(font.IsFixedWidth());
 	
 	wxClientDC dc(this);
-	dc.SetFont(*font);
+	dc.SetFont(font);
 	
 	wxSize char_extent = dc.GetTextExtent("X");
 	font_width  = char_extent.GetWidth();
@@ -74,7 +71,7 @@ REHex::CodeCtrl::CodeCtrl(wxWindow *parent, wxWindowID id):
 void REHex::CodeCtrl::append_line(off_t offset, const std::string &text, bool active)
 {
 	wxClientDC dc(this);
-	dc.SetFont(*font);
+	dc.SetFont(font);
 	
 	/* GetTextExtent() doesn't seem to handle tabs correctly, so we expand
 	 * them into spaces.
@@ -187,7 +184,7 @@ REHex::CodeCtrl::CodeCharRef REHex::CodeCtrl::char_near_abs_xy(int abs_x, int ab
 	int col = 0;
 	
 	wxClientDC dc(this);
-	dc.SetFont(*font);
+	dc.SetFont(font);
 	
 	while((code_xoff + dc.GetTextExtent(std::string((col + 1), 'X')).GetWidth()) < abs_x && col < (int)(line.text.length()))
 	{
@@ -253,7 +250,7 @@ void REHex::CodeCtrl::set_offset_display(REHex::OffsetBase offset_display_base, 
 	this->offset_display_upper_bound = offset_display_upper_bound;
 	
 	wxClientDC dc(this);
-	dc.SetFont(*font);
+	dc.SetFont(font);
 	
 	std::string offset_str = format_offset(0, offset_display_base, offset_display_upper_bound);
 	code_xoff = dc.GetTextExtent(offset_str + "  ").GetWidth();
@@ -279,7 +276,7 @@ void REHex::CodeCtrl::OnPaint(wxPaintEvent &event)
 	
 	wxBufferedPaintDC dc(this);
 	
-	dc.SetFont(*font);
+	dc.SetFont(font);
 	dc.SetBackground(*wxWHITE_BRUSH);
 	dc.SetBackgroundMode(wxTRANSPARENT);
 	

--- a/src/CodeCtrl.hpp
+++ b/src/CodeCtrl.hpp
@@ -52,7 +52,7 @@ namespace REHex {
 			
 			typedef std::pair<int, int> CodeCharRef;
 			
-			wxFont *font;
+			wxFont font;
 			int font_width;
 			int font_height;
 			int code_xoff;

--- a/src/DocumentCtrl.cpp
+++ b/src/DocumentCtrl.cpp
@@ -67,6 +67,7 @@ END_EVENT_TABLE()
 REHex::DocumentCtrl::DocumentCtrl(wxWindow *parent, SharedDocumentPointer &doc):
 	wxControl(),
 	doc(doc),
+	hex_font(wxFontInfo().Family(wxFONTFAMILY_MODERN)),
 	linked_scroll_prev(NULL),
 	linked_scroll_next(NULL),
 	redraw_cursor_timer(this, ID_REDRAW_CURSOR),
@@ -99,15 +100,11 @@ REHex::DocumentCtrl::DocumentCtrl(wxWindow *parent, SharedDocumentPointer &doc):
 	mouse_shift_initial = -1;
 	cursor_state      = Document::CSTATE_HEX;
 	
-	wxFontInfo finfo;
-	finfo.Family(wxFONTFAMILY_MODERN);
-	
-	hex_font = new wxFont(finfo);
-	assert(hex_font->IsFixedWidth());
+	assert(hex_font.IsFixedWidth());
 	
 	{
 		wxClientDC dc(this);
-		dc.SetFont(*hex_font);
+		dc.SetFont(hex_font);
 		
 		wxSize hf_char_size = dc.GetTextExtent("X");
 		hf_height           = hf_char_size.GetHeight();
@@ -387,7 +384,7 @@ void REHex::DocumentCtrl::OnPaint(wxPaintEvent &event)
 {
 	wxBufferedPaintDC dc(this);
 	
-	dc.SetFont(*hex_font);
+	dc.SetFont(hex_font);
 	
 	dc.SetBackground(wxBrush((*active_palette)[Palette::PAL_NORMAL_TEXT_BG]));
 	dc.Clear();
@@ -1825,7 +1822,7 @@ int REHex::DocumentCtrl::hf_string_width(int length)
 	}
 	
 	wxClientDC dc(this);
-	dc.SetFont(*hex_font);
+	dc.SetFont(hex_font);
 	
 	wxSize te = dc.GetTextExtent(std::string(length, 'X'));
 	return te.GetWidth();
@@ -2038,7 +2035,7 @@ void REHex::DocumentCtrl::DataRegion::draw(REHex::DocumentCtrl &doc, wxDC &dc, i
 {
 	draw_container(doc, dc, x, y);
 	
-	dc.SetFont(*(doc.hex_font));
+	dc.SetFont(doc.hex_font);
 	
 	wxPen norm_fg_1px((*active_palette)[Palette::PAL_NORMAL_TEXT_FG], 1);
 	wxPen selected_bg_1px((*active_palette)[Palette::PAL_SELECTED_TEXT_BG], 1);
@@ -2728,7 +2725,7 @@ void REHex::DocumentCtrl::CommentRegion::draw(REHex::DocumentCtrl &doc, wxDC &dc
 	int indent_width = doc._indent_width(indent_depth);
 	x += indent_width;
 	
-	dc.SetFont(*(doc.hex_font));
+	dc.SetFont(doc.hex_font);
 	
 	unsigned int row_chars = doc.hf_char_at_x(doc.virtual_width - (2 * indent_width)) - 1;
 	if(row_chars == 0)

--- a/src/DocumentCtrl.hpp
+++ b/src/DocumentCtrl.hpp
@@ -232,7 +232,7 @@ namespace REHex {
 			std::list<Region*> regions;
 			
 			/* Fixed-width font used for drawing hex data. */
-			wxFont *hex_font;
+			wxFont hex_font;
 			
 			/* Size of a character in hex_font. */
 			unsigned char hf_height;


### PR DESCRIPTION
MSVC runtime warned about the leaks.
According to wxWidgets font documentation (https://docs.wxwidgets.org/3.0/classwx_font.html) it is ok to use fonts like this, since they keep an internal reference count.
