### PR TITLE
Disable erase background

### DIFF
--- a/src/CodeCtrl.cpp
+++ b/src/CodeCtrl.cpp
@@ -27,6 +27,7 @@ enum {
 
 BEGIN_EVENT_TABLE(REHex::CodeCtrl, wxControl)
 	EVT_PAINT(REHex::CodeCtrl::OnPaint)
+	EVT_ERASE_BACKGROUND(REHex::CodeCtrl::OnErase)
 	EVT_SIZE(REHex::CodeCtrl::OnSize)
 	EVT_SCROLLWIN(REHex::CodeCtrl::OnScroll)
 	EVT_MOUSEWHEEL(REHex::CodeCtrl::OnWheel)
@@ -353,6 +354,11 @@ void REHex::CodeCtrl::OnPaint(wxPaintEvent &event)
 		
 		flush();
 	}
+}
+
+void REHex::CodeCtrl::OnErase(wxEraseEvent& event)
+{
+	// Left blank to disable erase
 }
 
 void REHex::CodeCtrl::OnSize(wxSizeEvent &event)

--- a/src/CodeCtrl.hpp
+++ b/src/CodeCtrl.hpp
@@ -88,6 +88,7 @@ namespace REHex {
 			void select_all();
 			
 			void OnPaint(wxPaintEvent &event);
+			void OnErase(wxEraseEvent &event);
 			void OnSize(wxSizeEvent &event);
 			void OnScroll(wxScrollWinEvent &event);
 			void OnWheel(wxMouseEvent &event);

--- a/src/DocumentCtrl.cpp
+++ b/src/DocumentCtrl.cpp
@@ -52,6 +52,7 @@ enum {
 
 BEGIN_EVENT_TABLE(REHex::DocumentCtrl, wxControl)
 	EVT_PAINT(REHex::DocumentCtrl::OnPaint)
+	EVT_ERASE_BACKGROUND(REHex::DocumentCtrl::OnErase)
 	EVT_SIZE(REHex::DocumentCtrl::OnSize)
 	EVT_SCROLLWIN(REHex::DocumentCtrl::OnScroll)
 	EVT_MOUSEWHEEL(REHex::DocumentCtrl::OnWheel)
@@ -417,6 +418,11 @@ void REHex::DocumentCtrl::OnPaint(wxPaintEvent &event)
 		
 		(*region)->draw(*this, dc, x_px, y_px);
 	}
+}
+
+void REHex::DocumentCtrl::OnErase(wxEraseEvent &event)
+{
+	// Left blank to disable erase
 }
 
 void REHex::DocumentCtrl::OnSize(wxSizeEvent &event)

--- a/src/DocumentCtrl.hpp
+++ b/src/DocumentCtrl.hpp
@@ -208,6 +208,7 @@ namespace REHex {
 			void replace_all_regions(std::list<Region*> &new_regions);
 			
 			void OnPaint(wxPaintEvent &event);
+			void OnErase(wxEraseEvent& event);
 			void OnSize(wxSizeEvent &event);
 			void OnScroll(wxScrollWinEvent &event);
 			void OnWheel(wxMouseEvent &event);


### PR DESCRIPTION
This is recommended on https://wiki.wxwidgets.org/Flicker-Free_Drawing
And fixes the flickering of the disassemble dialog, when text is selected (on windows)

DocumentCtrl is updated in the hope that it might increase performance.