### PR TITLE
Only update disassembly and decode panel when visible

### DIFF
--- a/src/CommentTree.cpp
+++ b/src/CommentTree.cpp
@@ -87,6 +87,11 @@ void REHex::CommentTree::load_state(wxConfig *config)
 	/* No state to load. */
 }
 
+void REHex::CommentTree::update()
+{
+	/* Nothing to update */
+}
+
 wxSize REHex::CommentTree::DoGetBestClientSize() const
 {
 	/* TODO: Calculate a reasonable best size. */

--- a/src/CommentTree.hpp
+++ b/src/CommentTree.hpp
@@ -78,6 +78,7 @@ namespace REHex {
 			
 			virtual void save_state(wxConfig *config) const override;
 			virtual void load_state(wxConfig *config) override;
+			virtual void update() override;
 			
 			virtual wxSize DoGetBestClientSize() const override;
 			

--- a/src/Tab.cpp
+++ b/src/Tab.cpp
@@ -423,6 +423,26 @@ void REHex::Tab::OnHToolChange(wxNotebookEvent& event)
 
 void REHex::Tab::OnVToolChange(wxBookCtrlEvent &event)
 {
+	if (event.GetOldSelection() != wxNOT_FOUND)
+	{
+		wxWindow* page = v_tools->GetPage(event.GetOldSelection());
+		assert(page != NULL);
+
+		ToolPanel* tp = dynamic_cast<ToolPanel*>(page);
+		assert(tp != NULL);
+		tp->set_visible(false);
+	}
+	
+	if (event.GetSelection() != wxNOT_FOUND)
+	{
+		wxWindow* page = v_tools->GetPage(event.GetSelection());
+		assert(page != NULL);
+
+		ToolPanel* tp = dynamic_cast<ToolPanel*>(page);
+		assert(tp != NULL);
+		tp->set_visible(true);
+	}
+	
 	vtools_adjust();
 }
 

--- a/src/ToolPanel.cpp
+++ b/src/ToolPanel.cpp
@@ -20,9 +20,21 @@
 #include "ToolPanel.hpp"
 
 REHex::ToolPanel::ToolPanel(wxWindow *parent):
-	wxPanel(parent) {}
+	wxPanel(parent),
+	is_visible(false)
+{
+}
 
 REHex::ToolPanel::~ToolPanel() {}
+
+void REHex::ToolPanel::set_visible(bool visible)
+{
+	is_visible = visible;
+	if (is_visible)
+	{
+		update();
+	}
+}
 
 std::map<std::string, const REHex::ToolPanelRegistration*> *REHex::ToolPanelRegistry::registrations = NULL;
 const std::map<std::string, const REHex::ToolPanelRegistration*> REHex::ToolPanelRegistry::no_registrations;

--- a/src/ToolPanel.hpp
+++ b/src/ToolPanel.hpp
@@ -58,9 +58,12 @@ namespace REHex {
 			
 			virtual void save_state(wxConfig *config) const = 0;
 			virtual void load_state(wxConfig *config) = 0;
+			virtual void update() = 0;
+			void set_visible(bool visible);
 			
 		protected:
 			ToolPanel(wxWindow *parent);
+			bool is_visible;
 	};
 	
 	class ToolPanelRegistration;

--- a/src/decodepanel.cpp
+++ b/src/decodepanel.cpp
@@ -241,6 +241,11 @@ wxSize REHex::DecodePanel::DoGetBestClientSize() const
 
 void REHex::DecodePanel::update()
 {
+	if (!is_visible)
+	{
+		/* There is no sense in updating this if we are not visible */
+		return;
+	}
 	assert(document != NULL);
 	
 	std::vector<unsigned char> data_at_cur;

--- a/src/decodepanel.hpp
+++ b/src/decodepanel.hpp
@@ -43,6 +43,7 @@ namespace REHex {
 			
 			virtual void save_state(wxConfig *config) const override;
 			virtual void load_state(wxConfig *config) override;
+			virtual void update() override;
 			
 			virtual wxSize DoGetBestClientSize() const override;
 			
@@ -73,8 +74,6 @@ namespace REHex {
 			wxStringProperty *f64;
 			
 			std::vector<unsigned char> last_data;
-			
-			void update();
 			
 			void OnCursorUpdate(CursorUpdateEvent &event);
 			void OnDataModified(OffsetLengthEvent &event);

--- a/src/disassemble.cpp
+++ b/src/disassemble.cpp
@@ -175,6 +175,11 @@ wxSize REHex::Disassemble::DoGetBestClientSize() const
 
 void REHex::Disassemble::update()
 {
+	if (!is_visible)
+	{
+		/* There is no sense in updating this if we are not visible */
+		return;
+	}
 	if(disassembler == 0)
 	{
 		assembly->clear();

--- a/src/disassemble.hpp
+++ b/src/disassemble.hpp
@@ -44,6 +44,7 @@ namespace REHex {
 			
 			virtual void save_state(wxConfig *config) const override;
 			virtual void load_state(wxConfig *config) override;
+			virtual void update() override;
 			
 			virtual wxSize DoGetBestClientSize() const override;
 			
@@ -62,7 +63,6 @@ namespace REHex {
 			CodeCtrl *assembly;
 			
 			void reinit_disassembler();
-			void update();
 			std::map<off_t, Instruction> disassemble(off_t offset, const void *code, size_t size);
 			
 			void OnCursorUpdate(CursorUpdateEvent &event);


### PR DESCRIPTION
This should speed up scrolling in the hex view with the cursor.

I verified that it builds correctly on a non-msvc build in mingw. (Should I test more setups before submitting a PR?)