### PR TITLE
Unhardcode linux launcher icon file type

### DIFF
--- a/res/rehex.desktop
+++ b/res/rehex.desktop
@@ -2,7 +2,7 @@
 Type=Application
 Encoding=UTF-8
 Name=Reverse Engineers' Hex Editor
-Icon=rehex.png
+Icon=rehex
 Exec=rehex %F
 Terminal=false
 Categories=Utility


### PR DESCRIPTION
Since the icon already is installed to a location compliant with [freedesktop.org standards](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html) you don't need to specify the full icon path or the file type extension in the launcher. 
The icon will be found anyway (without renaming anything).

Cf. this [example `.desktop` launcher](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#example) presented in the freedesktop.org documentation.