### PR TITLE
Mark a document dirty if highlighting is changed

### DIFF
--- a/src/document.cpp
+++ b/src/document.cpp
@@ -288,6 +288,8 @@ bool REHex::Document::set_highlight(off_t off, off_t length, int highlight_colou
 		[this, off, length, highlight_colour_idx]()
 		{
 			NestedOffsetLengthMap_set(highlights, off, length, highlight_colour_idx);
+			set_dirty(true);
+
 			_raise_highlights_changed();
 		},
 		
@@ -311,6 +313,8 @@ bool REHex::Document::erase_highlight(off_t off, off_t length)
 		[this, off, length]()
 		{
 			highlights.erase(NestedOffsetLengthMapKey(off, length));
+			set_dirty(true);
+
 			_raise_highlights_changed();
 		},
 		


### PR DESCRIPTION
Without this the settings won't be saved if only highlighting changed