### PR TITLE
Fix the crash described in #113

### DIFF
--- a/src/Tab.cpp
+++ b/src/Tab.cpp
@@ -619,7 +619,8 @@ void REHex::Tab::OnDocumentCtrlChar(wxKeyEvent &event)
 		{
 			if(selection_length > 0)
 			{
-				doc->erase_data(selection_off, selection_length, (selection_off - 1), Document::CSTATE_GOTO, "delete selection");
+				off_t new_cursor_pos = std::max<off_t>(0, selection_off - 1);
+				doc->erase_data(selection_off, selection_length, new_cursor_pos, Document::CSTATE_GOTO, "delete selection");
 				doc_ctrl->clear_selection();
 			}
 			else if((cursor_pos + 1) < doc->buffer_length())


### PR DESCRIPTION
This crashes because `REHex::Document::erase_data` tries to normalize the cursor pos from `-1` (the selection is starting at 0, so the `-1` comes from `(selection_off - 1)`.
However to normalize it, the `cpos_off` is used from before the deletion is done, which is `1` at that point.