### PR TITLE
Fix call to png2icns

### DIFF
--- a/Makefile.osx
+++ b/Makefile.osx
@@ -76,6 +76,7 @@ REHex.app: res/Info.plist $(EXE) $(ICNS) help/rehex.htb
 	done
 
 $(ICNS): res/icon16.png res/icon32.png res/icon256.png res/icon512.png
+ifneq ($(ICONUTIL),)
 	rm -rf $(ICONSET)
 	mkdir $(ICONSET)
 	cp res/icon16.png   $(ICONSET)/icon_16x16.png
@@ -88,11 +89,9 @@ $(ICNS): res/icon16.png res/icon32.png res/icon256.png res/icon512.png
 	cp res/icon512.png  $(ICONSET)/icon_256x256@2x.png
 	cp res/icon512.png  $(ICONSET)/icon_512x512.png
 	cp res/icon1024.png $(ICONSET)/icon_512x512@2x.png
-	
-ifneq ($(ICONUTIL),)
 	$(ICONUTIL) -c icns -o $@ $(ICONSET)
 else ifneq ($(PNG2ICNS),)
-	$(PNG2ICNS) $@ $(filter-out %@2x.png,$(wildcard $(ICONSET)/*.png))
+	$(PNG2ICNS) $@ res/icon{16,32,128,256,512}.png
 else
 	$(error Neither iconutil nor png2icns found in PATH. Install one or set ICONUTIL/PNG2ICNS as necessary)
 endif


### PR DESCRIPTION
The current call to `png2icns` is not working because make's `wildcard` function is evaluated at parsing time and the `$(ICONSET)` directory does not yet exist.
[Someone here](https://www.cmcrossroads.com/article/trouble-wildcard) explained that better than I could.

This results in `png2icns` being called without the required arguments:

```session
png2icns res/REHex.icns
Usage: png2icns file.icns file1.png file2.png ... filen.png
make: *** [Makefile.osx:91: res/REHex.icns] Error 1
```

Moreover, there is no need to copy files around when we're not using `iconutils` since we are going to ignore @2x variants anyway. Instead `png2icns` can take its inputs directly from the `res/` directory.
That's why I moved up the `ifneq ($(ICONUTIL),)` test.