### PR TITLE
Add dependencies homepage for lesser known ones

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -20,7 +20,7 @@ The following libraries are required for building/running REHex:
  - [Jansson](https://www.digip.org/jansson/)
  - libunistring
  - Lua (5.3+)
- - Template Toolkit (unless help is disabled)
+ - [Template Toolkit](https://template-toolkit.org/) (unless help is disabled)
  - wxWidgets
 
 ## Makefile environment variables

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -16,7 +16,7 @@ REHex is compiled using a (GNU) Makefile, most of the common targets (e.g. `all`
 The following libraries are required for building/running REHex:
 
  - [Botan](https://botan.randombit.net/)
- - Capstone
+ - [Capstone](https://www.capstone-engine.org/)
  - Jansson
  - libunistring
  - Lua (5.3+)

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -17,7 +17,7 @@ The following libraries are required for building/running REHex:
 
  - [Botan](https://botan.randombit.net/)
  - [Capstone](https://www.capstone-engine.org/)
- - Jansson
+ - [Jansson](https://www.digip.org/jansson/)
  - libunistring
  - Lua (5.3+)
  - Template Toolkit (unless help is disabled)

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -15,7 +15,7 @@ REHex is compiled using a (GNU) Makefile, most of the common targets (e.g. `all`
 
 The following libraries are required for building/running REHex:
 
- - Botan
+ - [Botan](https://botan.randombit.net/)
  - Capstone
  - Jansson
  - libunistring


### PR DESCRIPTION
Some deps are well known, some are not. 

Adding the homepage of the one that are not helps understanding what's needed.