### PR TITLE
Add QuietUninstallString to registry

### DIFF
--- a/nsis/rehex.nsi
+++ b/nsis/rehex.nsi
@@ -127,6 +127,7 @@ Section "Application" SecApp
 	; Registry information for add/remove programs
 	WriteRegStr HKEY_LOCAL_MACHINE "Software\Microsoft\Windows\CurrentVersion\Uninstall\REHex" "DisplayName" "Reverse Engineers' Hex Editor"
 	WriteRegStr HKEY_LOCAL_MACHINE "Software\Microsoft\Windows\CurrentVersion\Uninstall\REHex" "UninstallString" "$INSTDIR\Uninstall.exe"
+	WriteRegStr HKEY_LOCAL_MACHINE "Software\Microsoft\Windows\CurrentVersion\Uninstall\REHex" "QuietUninstallString" "$INSTDIR\Uninstall.exe /S"
 	WriteRegStr HKEY_LOCAL_MACHINE "Software\Microsoft\Windows\CurrentVersion\Uninstall\REHex" "InstallLocation" "$INSTDIR"
 	WriteRegStr HKEY_LOCAL_MACHINE "Software\Microsoft\Windows\CurrentVersion\Uninstall\REHex" "DisplayIcon" "$INSTDIR\rehex.exe"
 	WriteRegStr HKEY_LOCAL_MACHINE "Software\Microsoft\Windows\CurrentVersion\Uninstall\REHex" "Publisher" "Daniel Collins"


### PR DESCRIPTION
This helps tools like WinGet automatically uninstall without user intervention. Running `winget uninstall` with the changed installer will correctly uninstall without the UI appearing.