### PR TITLE
Makefile.osx: fallback to makeicns

### DIFF
--- a/Makefile.osx
+++ b/Makefile.osx
@@ -16,6 +16,7 @@
 
 ICONUTIL ?= $(shell which iconutil > /dev/null && echo iconutil)
 PNG2ICNS ?= $(shell which png2icns > /dev/null && echo png2icns)
+MAKEICNS ?= $(shell which makeicns > /dev/null && echo makeicns)
 
 EXTRA_APP_OBJS := \
 	res/backward32.o \
@@ -106,8 +107,10 @@ ifneq ($(ICONUTIL),)
 	$(ICONUTIL) -c icns -o $@ $(ICONSET)
 else ifneq ($(PNG2ICNS),)
 	$(PNG2ICNS) $@ res/icon{16,32,128,256,512}.png
+else ifneq ($(MAKEICNS),)
+	$(MAKEICNS) -16 res/icon16.png -32 res/icon32.png -128 res/icon128.png -256 res/icon256.png -512 res/icon512.png -out $@
 else
-	$(error Neither iconutil nor png2icns found in PATH. Install one or set ICONUTIL/PNG2ICNS as necessary)
+	$(error Neither iconutil, png2icns nor makeicns found in PATH. Install one or set ICONUTIL/PNG2ICNS/MAKEICNS as necessary)
 endif
 
 REHex.dmg: REHex.app


### PR DESCRIPTION
A portable way of generating icons using makeicns port: https://ports.macports.org/port/makeicns/details